### PR TITLE
Attempt to resolve duplicate webhook calls

### DIFF
--- a/slack.py
+++ b/slack.py
@@ -31,7 +31,7 @@ class SlackStatusPush(StatusReceiverMultiService):
     return self  # subscribe to this builder
 
   def buildFinished(self, builder_name, build, result):
-    if (builder_name != self.builder_name):
+    if (self.builder_name and builder_name != self.builder_name):
       return
     url = self.master_status.getURLForThing(build)
     if self.localhost_replace:


### PR DESCRIPTION
For me, when I pushed multiple statuses, I'd get duplicate messages in slack for the second append:

```
c['status'].append(slack.SlackStatusPush("subdomain", "key", "#channel1", "localhost", "project1"))
c['status'].append(slack.SlackStatusPush("subdomain", "key", "#channel2", "localhost", "project2"))
```

When project2 build completed, I'd get a message in both #channel1 and #channel2. For me, the changes in this PR resolved the problem.
