### PR TITLE
Update slack.py

### DIFF
--- a/slack.py
+++ b/slack.py
@@ -36,8 +36,6 @@ class SlackStatusPush(StatusReceiverMultiService):
     url = self.master_status.getURLForThing(build)
     if self.localhost_replace:
       url = url.replace("//localhost", "//%s" % self.localhost_replace)
-    if self.builder_name:
-      builder_name = self.builder_name
 
     if result == SUCCESS:
       icon = ":buildbot_success:"


### PR DESCRIPTION
You can remove this check.

```
if self.builder_name:
    builder_name = self.builder_name
```

As this already take care of it.

```
if (self.builder_name and builder_name != self.builder_name):
       return
```
