### PR TITLE
Add a few more options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,26 @@ c['status'].append(slack.SlackStatusPush("YOUR_SLACK_WEBURL"))
 ### Additional Options:
 ```
   localhost_replace = False
-  builder_name = False
   username = None
-  icon = None
+  icons = None
   notify_on_success = True
   notify_on_failure = True
+  builders = None
 ```
 
 ### Complete Example:
 
 ```
 import slack
-c['status'].append(slack.SlackStatusPush("YOUR_SLACK_WEBURL", "http://ci.mindmatters.de", "mindmatters Builder", None, None, False, True)
+slack_status = slack.SlackStatusPush(
+    "YOUR_SLACK_WEBURL",
+    localhost_replace="http://ci.mindmatters.de",
+    username="mindmatters Buildbot",
+    icons=(':full_moon_with_face:', ':umbrella:'),
+    notify_on_success=False,
+    notify_on_failure=True,
+)
+c['status'].append(slack_status)
 ```
 
 Enjoy!

--- a/slack.py
+++ b/slack.py
@@ -28,6 +28,8 @@ class SlackStatusPush(StatusReceiverMultiService):
             messages when a build was successful.
         :param notify_on_failure: Set this to False if you don't want
             messages when a build failed.
+        :param builders: List of builder names to filter on. The default value
+            of None will result in notifications for every builder.
         """
 
         StatusReceiverMultiService.__init__(self)

--- a/slack.py
+++ b/slack.py
@@ -12,7 +12,7 @@ class SlackStatusPush(StatusReceiverMultiService):
 
     def __init__(self, weburl,
                  localhost_replace=False, username=None,
-                 icon=None, notify_on_success=True, notify_on_failure=True,
+                 icons=None, notify_on_success=True, notify_on_failure=True,
                  **kwargs):
         """
         Creates a SlackStatusPush status service.
@@ -23,7 +23,7 @@ class SlackStatusPush(StatusReceiverMultiService):
             change this by setting this variable to true.
         :param username: The user name of the "user" positing the messages on
             Slack.
-        :param icon: The icon of the "user" posting the messages on Slack.
+        :param icons: tuple str (succ, fail) emoji names or icon urls
         :param notify_on_success: Set this to False if you don't want
             messages when a build was successful.
         :param notify_on_failure: Set this to False if you don't want
@@ -35,7 +35,7 @@ class SlackStatusPush(StatusReceiverMultiService):
         self.weburl = weburl
         self.localhost_replace = localhost_replace
         self.username = username
-        self.icon = icon
+        self.icons = icons
         self.notify_on_success = notify_on_success
         self.notify_on_failure = notify_on_failure
         self.watched = []
@@ -127,10 +127,8 @@ class SlackStatusPush(StatusReceiverMultiService):
         if self.username:
             payload['username'] = self.username
 
-        if self.icon:
-            if self.icon.startswith(':'):
-                payload['icon_emoji'] = self.icon
-            else:
-                payload['icon_url'] = self.icon
+        if self.icons:
+            icon = self.icons[0 if result == SUCCESS else 1]
+            payload['icon_emoji' if icon.startswith(':') else 'icon_url'] = icon
 
         requests.post(self.weburl, data=json.dumps(payload))

--- a/slack.py
+++ b/slack.py
@@ -1,5 +1,5 @@
 from buildbot.status.base import StatusReceiverMultiService
-from buildbot.status.builder import Results, SUCCESS
+from buildbot.status.builder import SUCCESS
 import requests
 import json
 
@@ -11,8 +11,8 @@ class SlackStatusPush(StatusReceiverMultiService):
     """
 
     def __init__(self, weburl,
-                 localhost_replace=False, username=None,
-                 icons=None, notify_on_success=True, notify_on_failure=True,
+                 localhost_replace=False, username=None, icons=None,
+                 builders=None, notify_on_success=True, notify_on_failure=True,
                  **kwargs):
         """
         Creates a SlackStatusPush status service.
@@ -36,6 +36,7 @@ class SlackStatusPush(StatusReceiverMultiService):
         self.localhost_replace = localhost_replace
         self.username = username
         self.icons = icons
+        self.builders = builders
         self.notify_on_success = notify_on_success
         self.notify_on_failure = notify_on_failure
         self.watched = []
@@ -62,6 +63,9 @@ class SlackStatusPush(StatusReceiverMultiService):
             return
 
         if not self.notify_on_failure and result != SUCCESS:
+            return
+
+        if self.builders and builder_name not in self.builders:
             return
 
         build_url = self.master_status.getURLForThing(build)


### PR DESCRIPTION
I'm setting up a Buildbot instance for my company and made a few changes here.
- `icon` has become `icons` and is a 2-tup so the Slack user can have a different face depending on success or failure. I opted for :full_moon_with_face: and :umbrella: respectively :-)
- `builders` accepts a list of builder names that should trigger this status. I ended up using lots of builders that were controlled by a "root" builder, so only wanted notifications from that.

The `icon`/`icons` change is not backwards compatible, so I could split this PR if you'd rather.

Greets,

Ben
